### PR TITLE
fix: test using incorrect return index

### DIFF
--- a/test/PostMaster.t.sol
+++ b/test/PostMaster.t.sol
@@ -96,7 +96,7 @@ contract PostMasterTest is Test {
         // and an array of 1
         uint8[] memory depths = new uint8[](1);
         depths[0] = 18;
-        (, uint256 xdaiRequiredMany) = pm.quotexDAIMany(500_000, depths);
+        (uint256 xdaiRequiredMany, ) = pm.quotexDAIMany(500_000, depths);
 
         // Check the invariants
         assertEq(xdaiRequired, xdaiRequiredMany);


### PR DESCRIPTION
In re-ordering some return tuples to ensure consistency across methods, the tests weren't modified.

This fixes the ordering of a return type and fixes tests.