### PR TITLE
cicd: add fork for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
         id: build
 
       - name: Run Forge tests
+        env:
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
-          forge test -vvv
+          forge test --rpc-url $RPC_URL -vvv
         id: test


### PR DESCRIPTION
This PR:

1. Adds in `RPC_URL` for fork testing using `forge --rpc-url`.